### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/path-toolkit.js
+++ b/src/path-toolkit.js
@@ -64,6 +64,16 @@ var wildCardMatch = function(template, str){
 };
 
 /**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param {String} key key for check, string.
+ * @returns {Boolean}.
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'prototype', 'constructor'].includes(key);
+}
+
+/**
  * Inspect input value and determine whether it is an Object or not.
  * Values of undefined and null will return "false", otherwise
  * must be of type "object" or "function".
@@ -1035,7 +1045,10 @@ var PathToolkit = function(options){
                     obj[tk[i]] = {};
                 }
             }
-            obj = obj[tk[i++]];
+            if (!isPrototypePolluted(tk[i])) {
+              obj = obj[tk[i]];
+            }
+            i++;
         }
         return obj;
     };

--- a/test/path-toolkit.js
+++ b/test/path-toolkit.js
@@ -667,6 +667,16 @@ describe( 'PathToolkit', function(){
             expect(result).to.be.true;
             expect(ary.join(',')).to.equal('NEW,NEW,NEW');
         });
+
+        it('should prevent prototype pollution', function() {
+          var str = '__proto__.polluted';
+          var obj = {};
+          var result = ptk.set(obj, str, 'Yes, its polluted.');
+          expect(result).to.be.true;
+          expect(obj.polluted).to.be.equal('Yes, its polluted.');
+          expect({}.polluted).to.not.be.equal('Yes, its polluted.');
+          expect({}.polluted).to.be.equal(undefined);
+        })
     });
 
     describe( 'find', function(){


### PR DESCRIPTION
https://huntr.dev/users/d3v53c has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/path-toolkit/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/path-toolkit/1/README.md

### User Comments:

### 📊 Metadata *

path-toolkit is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-path-toolkit/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
var pathToolkit = require("path-toolkit")
var ptk = new pathToolkit();
var obj = {}
console.log("Before : " + {}.polluted);
ptk.set(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```

Execute the following commands in terminal:

```
npm i path-toolkit # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/102822564-52cfbe80-43ff-11eb-9065-fcbb0a0d971f.png)

After:
![image](https://user-images.githubusercontent.com/64132745/102822599-68dd7f00-43ff-11eb-8fcb-28dca6d80812.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/104701126-1e6bcb80-573b-11eb-8733-e3de6ad88e8b.png)

![image](https://user-images.githubusercontent.com/64132745/104701646-3e9b8a80-573b-11eb-9995-930f4c0c3c4c.png)

![image](https://user-images.githubusercontent.com/64132745/104701920-4eb36a00-573b-11eb-89b5-f9e7e86a2bdf.png)

![image](https://user-images.githubusercontent.com/64132745/104701953-596dff00-573b-11eb-9c41-e2fadce8f59c.png)



After fix, the functionality is unaffected.

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-npm-path-toolkit/
